### PR TITLE
doc: show bin/ instead of sbin/ path

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,9 @@ sensiolabs_minify:
         # set it to 'auto' to let the bundle try to find the location of the binary
         local_binary: 'auto'
 
-        #  you can also define the path to the binary explicitly, but this won't work
+        # you can also define the path to the binary explicitly, but this won't work
         # if you run the application in multiple servers with different binary locations
-        local_binary: "/usr/local/sbin/minify"
+        local_binary: "/usr/local/bin/minify"
 ```
 
 ## Credits


### PR DESCRIPTION
`sbin` is for "*programs for system administration*", `minify` doesn't need this.

Source: https://askubuntu.com/questions/308045/differences-between-bin-sbin-usr-bin-usr-sbin-usr-local-bin-usr-local/1045759#1045759

On Ubuntu 24.04, `apt install minify` create a binary in `/usr/bin/minify`, so `/usr/local/bin/` (or `/usr/bin/`) will be closer to the actual path.