### PR TITLE
doc: fix command name minify:asset

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,11 +121,11 @@ Then, run the following command to minify assets:
 
 ```shell
 # this outputs the result in the console
-php bin/console minify:assets css/main.css
+php bin/console minify:asset css/main.css
 
 # this will write the output into the 'main.min.css' file
 # (the given output file is created / overwritten if needed)
-php bin/console minify:assets css/main.css css/main.min.css
+php bin/console minify:asset css/main.css css/main.min.css
 ```
 
 ## Configuration


### PR DESCRIPTION
There is no `s` at the end: https://github.com/sensiolabs/minify-bundle/blob/655f29e6b839aa1df035ed904575ca606ff187d0/src/Command/MinifyAssetCommand.php#L31