### PR TITLE
Map aarch64 to arm64 to fix docker issue on MacOS with Apple ARM chips

### DIFF
--- a/src/Minifier/SystemUtils.php
+++ b/src/Minifier/SystemUtils.php
@@ -64,7 +64,7 @@ final class SystemUtils
     {
         return match (\strtolower($architecture)) {
             'amd64', 'x86_64' => self::ARCH_AMD64,
-            'arm64' => self::ARCH_ARM64,
+            'aarch64', 'arm64' => self::ARCH_ARM64,
             'i386', 'i686' => self::ARCH_X86,
             default => null,
         };


### PR DESCRIPTION
fixes #18