### PR TITLE
remove install command if download is disabled

### DIFF
--- a/src/SensiolabsMinifyBundle.php
+++ b/src/SensiolabsMinifyBundle.php
@@ -58,6 +58,7 @@ final class SensiolabsMinifyBundle extends AbstractBundle
         if (!$config['minify']['download_binary']) {
             $container->services()
                 ->remove('.sensiolabs_minify.minifier.minify_installer')
+                ->remove('.sensiolabs_minify.command.minify_install')
             ;
         }
 


### PR DESCRIPTION
When setting `download_binary` to `false` the following exception is thrown:
`The service ".sensiolabs_minify.command.minify_install" has a dependency on a non-existent service ".sensiolabs_minify.minifier.minify_installer". Did you mean this: "sensiolabs_minify.minifier.minify"?`

So the install command should also be removed if `download_binary` is `false`.