### PR TITLE
Add HTML support (with options!)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /.php-cs-fixer.cache
 /composer.lock
 /phpunit.xml
+/tests/Fixtures/config/
 /tests/Fixtures/var/
 /vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.3.0
 
 - Add HTML support (`MinifierInterface::TYPE_HTML`)
-- Add options support to `MinifierInterface::minify()` via the `OptionsInterface` DTO (BC-compatible, third argument)
+- Add options support to `MinifierInterface::minify()` via a third, optional `OptionsInterface` argument. This argument will become part of the signature in 2.0.
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 1.3.0
+
+- Add HTML support (`MinifierInterface::TYPE_HTML`)
+- Add options support to `MinifierInterface::minify()` via the `OptionsInterface` DTO (BC-compatible, third argument)
+
+## 1.2.0
+
+- Add Symfony 8 support
+
 ## 1.1.0
 
 - Support for PHP 8.1.0 or higher

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,11 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$options$#"
+			count: 1
+			path: src/Minifier/MinifierInterface.php
+
+		-
+			message: "#^Method Sensiolabs\\\\MinifyBundle\\\\Minifier\\\\MinifierInterface\\:\\:minify\\(\\) invoked with 3 parameters, 2 required\\.$#"
+			count: 1
+			path: src/Minifier/TraceableMinifier.php

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,3 +1,6 @@
+includes:
+    - phpstan-baseline.neon
+
 parameters:
     level: 9
     paths:

--- a/src/Minifier/MinifierInterface.php
+++ b/src/Minifier/MinifierInterface.php
@@ -20,9 +20,10 @@ interface MinifierInterface
 {
     public const TYPE_CSS = 'css';
     public const TYPE_JS = 'js';
+    public const TYPE_HTML = 'html';
 
     /**
-     * @param self::TYPE_CSS|self::TYPE_JS $type
+     * @param self::TYPE_CSS|self::TYPE_JS|self::TYPE_HTML $type
      */
-    public function minify(string $input, string $type): string;
+    public function minify(string $input, string $type/* , ?\Sensiolabs\MinifyBundle\Minifier\Options\OptionsInterface $options = null */): string;
 }

--- a/src/Minifier/MinifierInterface.php
+++ b/src/Minifier/MinifierInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Sensiolabs\MinifyBundle\Minifier;
 
+use Sensiolabs\MinifyBundle\Minifier\Options\OptionsInterface;
+
 /**
  * @author Simon André <smn.andre@gmail.com>
  */
@@ -24,6 +26,7 @@ interface MinifierInterface
 
     /**
      * @param self::TYPE_CSS|self::TYPE_JS|self::TYPE_HTML $type
+     * @param OptionsInterface|null                        $options
      */
-    public function minify(string $input, string $type/* , ?\Sensiolabs\MinifyBundle\Minifier\Options\OptionsInterface $options = null */): string;
+    public function minify(string $input, string $type/* , ?OptionsInterface $options = null */): string;
 }

--- a/src/Minifier/Options/HtmlOptions.php
+++ b/src/Minifier/Options/HtmlOptions.php
@@ -15,6 +15,9 @@ namespace Sensiolabs\MinifyBundle\Minifier\Options;
 
 use Sensiolabs\MinifyBundle\Minifier\MinifierInterface;
 
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
 final class HtmlOptions implements OptionsInterface
 {
     /**

--- a/src/Minifier/Options/HtmlOptions.php
+++ b/src/Minifier/Options/HtmlOptions.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SensioLabs MinifyBundle package.
+ *
+ * (c) Simon André - Sensiolabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensiolabs\MinifyBundle\Minifier\Options;
+
+use Sensiolabs\MinifyBundle\Minifier\MinifierInterface;
+
+final class HtmlOptions implements OptionsInterface
+{
+    /**
+     * @param bool $keepDocumentTags preserve html, head and body tags
+     */
+    public function __construct(
+        public readonly bool $keepDocumentTags = false,
+    ) {
+    }
+
+    public function getType(): string
+    {
+        return MinifierInterface::TYPE_HTML;
+    }
+
+    public function toCliArgs(): array
+    {
+        $args = [];
+        if ($this->keepDocumentTags) {
+            $args[] = '--html-keep-document-tags';
+        }
+
+        return $args;
+    }
+}

--- a/src/Minifier/Options/OptionsInterface.php
+++ b/src/Minifier/Options/OptionsInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SensioLabs MinifyBundle package.
+ *
+ * (c) Simon André - Sensiolabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensiolabs\MinifyBundle\Minifier\Options;
+
+use Sensiolabs\MinifyBundle\Minifier\MinifierInterface;
+
+interface OptionsInterface
+{
+    /**
+     * @return MinifierInterface::TYPE_*
+     */
+    public function getType(): string;
+
+    /**
+     * @return list<string>
+     */
+    public function toCliArgs(): array;
+}

--- a/src/Minifier/Options/OptionsInterface.php
+++ b/src/Minifier/Options/OptionsInterface.php
@@ -15,6 +15,9 @@ namespace Sensiolabs\MinifyBundle\Minifier\Options;
 
 use Sensiolabs\MinifyBundle\Minifier\MinifierInterface;
 
+/**
+ * @author Hugo Alliaume <hugo@alliau.me>
+ */
 interface OptionsInterface
 {
     /**

--- a/src/Minifier/TraceableMinifier.php
+++ b/src/Minifier/TraceableMinifier.php
@@ -27,8 +27,10 @@ final class TraceableMinifier implements MinifierInterface
     ) {
     }
 
-    public function minify(string $input, string $type/* , ?\Sensiolabs\MinifyBundle\Minifier\Options\OptionsInterface $options = null */): string
+    public function minify(string $input, string $type/* , ?OptionsInterface $options = null */): string
     {
+        $options = \func_num_args() > 2 ? \func_get_arg(2) : null;
+
         $inputSize = strlen($input);
         $this->logger->debug('Minify command input: {inputSize} kB', [
             'inputSize' => round($inputSize / 1024, 1),
@@ -36,7 +38,7 @@ final class TraceableMinifier implements MinifierInterface
         ]);
 
         $timeStart = microtime(true);
-        $output = $this->minifier->minify(...\func_get_args());
+        $output = $this->minifier->minify($input, $type, $options);
         $timeEnd = microtime(true);
 
         $outputSize = strlen($output);

--- a/src/Minifier/TraceableMinifier.php
+++ b/src/Minifier/TraceableMinifier.php
@@ -27,7 +27,7 @@ final class TraceableMinifier implements MinifierInterface
     ) {
     }
 
-    public function minify(string $input, string $type): string
+    public function minify(string $input, string $type/* , ?\Sensiolabs\MinifyBundle\Minifier\Options\OptionsInterface $options = null */): string
     {
         $inputSize = strlen($input);
         $this->logger->debug('Minify command input: {inputSize} kB', [
@@ -36,7 +36,7 @@ final class TraceableMinifier implements MinifierInterface
         ]);
 
         $timeStart = microtime(true);
-        $output = $this->minifier->minify($input, $type);
+        $output = $this->minifier->minify(...\func_get_args());
         $timeEnd = microtime(true);
 
         $outputSize = strlen($output);

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -31,15 +31,15 @@ final class Minify implements MinifierInterface
     public function minify(string $input, string $type/* , ?OptionsInterface $options = null */): string
     {
         $options = \func_num_args() > 2 ? \func_get_arg(2) : null;
-        if ($options !== null && !$options instanceof OptionsInterface) {
+        if (null !== $options && !$options instanceof OptionsInterface) {
             throw new RuntimeException(sprintf('Expected $options to be an instance of "%s", got "%s".', OptionsInterface::class, get_debug_type($options)));
         }
-        if ($options !== null && $options->getType() !== $type) {
+        if (null !== $options && $options->getType() !== $type) {
             throw new RuntimeException(sprintf('Options type "%s" does not match minify type "%s".', $options->getType(), $type));
         }
 
         $args = [$this->binaryPath, '--type', $type];
-        if ($options !== null) {
+        if (null !== $options) {
             $args = [...$args, ...$options->toCliArgs()];
         }
 

--- a/src/Minify.php
+++ b/src/Minify.php
@@ -15,6 +15,7 @@ namespace Sensiolabs\MinifyBundle;
 
 use Sensiolabs\MinifyBundle\Exception\RuntimeException;
 use Sensiolabs\MinifyBundle\Minifier\MinifierInterface;
+use Sensiolabs\MinifyBundle\Minifier\Options\OptionsInterface;
 use Symfony\Component\Process\Process;
 
 /**
@@ -27,9 +28,22 @@ final class Minify implements MinifierInterface
     ) {
     }
 
-    public function minify(string $input, string $type): string
+    public function minify(string $input, string $type/* , ?OptionsInterface $options = null */): string
     {
-        $process = new Process([$this->binaryPath, '--type',  $type]);
+        $options = \func_num_args() > 2 ? \func_get_arg(2) : null;
+        if ($options !== null && !$options instanceof OptionsInterface) {
+            throw new RuntimeException(sprintf('Expected $options to be an instance of "%s", got "%s".', OptionsInterface::class, get_debug_type($options)));
+        }
+        if ($options !== null && $options->getType() !== $type) {
+            throw new RuntimeException(sprintf('Options type "%s" does not match minify type "%s".', $options->getType(), $type));
+        }
+
+        $args = [$this->binaryPath, '--type', $type];
+        if ($options !== null) {
+            $args = [...$args, ...$options->toCliArgs()];
+        }
+
+        $process = new Process($args);
         $process->setInput($input);
 
         try {

--- a/tests/Fixtures/bin/fakify
+++ b/tests/Fixtures/bin/fakify
@@ -5,7 +5,7 @@ if (!isset($argv[1]) || '--type' !== $argv[1] || !isset($argv[2])) {
     echo 'ERROR: Missing type argument.';
     exit(1);
 }
-if (!in_array($argv[2], ['css', 'js'])) {
+if (!in_array($argv[2], ['css', 'js', 'html'])) {
     echo 'ERROR: Invalid type argument.';
     exit(1);
 }
@@ -15,14 +15,20 @@ $input = file_get_contents('php://stdin');
 
 if ('css' === $typeArg) {
     file_put_contents('php://stdout', $input);
-    
+
+    return;
+}
+
+if ('html' === $typeArg) {
+    $extraArgs = array_slice($argv, 3);
+    file_put_contents('php://stdout', $input.'|args='.implode(' ', $extraArgs));
+
     return;
 }
 
 if ('js' === $typeArg) {
 //    file_put_contents('php://stdout', $input);
     exit(20000000);
-    
+
     return;
 }
-

--- a/tests/Minifier/Options/HtmlOptionsTest.php
+++ b/tests/Minifier/Options/HtmlOptionsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the SensioLabs MinifyBundle package.
+ *
+ * (c) Simon André - Sensiolabs
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sensiolabs\MinifyBundle\Tests\Minifier\Options;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Sensiolabs\MinifyBundle\Minifier\MinifierInterface;
+use Sensiolabs\MinifyBundle\Minifier\Options\HtmlOptions;
+
+#[CoversClass(HtmlOptions::class)]
+class HtmlOptionsTest extends TestCase
+{
+    public function testGetTypeReturnsHtml(): void
+    {
+        $this->assertSame(MinifierInterface::TYPE_HTML, (new HtmlOptions())->getType());
+    }
+
+    public function testToCliArgsIsEmptyByDefault(): void
+    {
+        $this->assertSame([], (new HtmlOptions())->toCliArgs());
+    }
+
+    public function testToCliArgsIncludesKeepDocumentTagsFlag(): void
+    {
+        $this->assertSame(
+            ['--html-keep-document-tags'],
+            (new HtmlOptions(keepDocumentTags: true))->toCliArgs(),
+        );
+    }
+}

--- a/tests/Minifier/TraceableMinifierTest.php
+++ b/tests/Minifier/TraceableMinifierTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Sensiolabs\MinifyBundle\Minifier\MinifierInterface;
+use Sensiolabs\MinifyBundle\Minifier\Options\HtmlOptions;
 use Sensiolabs\MinifyBundle\Minifier\TraceableMinifier;
 
 #[CoversClass(TraceableMinifier::class)]
@@ -62,6 +63,20 @@ class TraceableMinifierTest extends TestCase
 
         $traceableMinifier = new TraceableMinifier($minifier);
         $this->assertSame('', $traceableMinifier->minify('', 'css'));
+    }
+
+    public function testMinifyForwardsOptionsToInnerMinifier(): void
+    {
+        $options = new HtmlOptions(keepDocumentTags: true);
+
+        $minifier = $this->createMock(MinifierInterface::class);
+        $minifier->expects($this->once())
+            ->method('minify')
+            ->with('input content', 'html', $options)
+            ->willReturn('minified content');
+
+        $traceableMinifier = new TraceableMinifier($minifier);
+        $this->assertSame('minified content', $traceableMinifier->minify('input content', 'html', $options));
     }
 
     public function testMinifyHandlesExceptionFromMinifier(): void

--- a/tests/MinifyTest.php
+++ b/tests/MinifyTest.php
@@ -16,6 +16,7 @@ namespace Sensiolabs\MinifyBundle\Tests;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Sensiolabs\MinifyBundle\Exception\RuntimeException;
+use Sensiolabs\MinifyBundle\Minifier\Options\HtmlOptions;
 use Sensiolabs\MinifyBundle\Minify;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -56,5 +57,30 @@ class MinifyTest extends TestCase
         $minify = new Minify(self::FIXTURES_BINARY_PATH);
 
         $minify->minify('input content', 'foo');
+    }
+
+    public function testMinifyForwardsOptionsCliArgs(): void
+    {
+        $minify = new Minify(self::FIXTURES_BINARY_PATH);
+        $output = $minify->minify('<html></html>', 'html', new HtmlOptions(keepDocumentTags: true));
+
+        $this->assertSame('<html></html>|args=--html-keep-document-tags', $output);
+    }
+
+    public function testMinifyPassesNoExtraArgsWhenOptionsHaveNoFlags(): void
+    {
+        $minify = new Minify(self::FIXTURES_BINARY_PATH);
+        $output = $minify->minify('<html></html>', 'html', new HtmlOptions());
+
+        $this->assertSame('<html></html>|args=', $output);
+    }
+
+    public function testMinifyThrowsWhenOptionsTypeDoesNotMatch(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Options type "html" does not match minify type "css".');
+
+        $minify = new Minify(self::FIXTURES_BINARY_PATH);
+        $minify->minify('input', 'css', new HtmlOptions());
     }
 }


### PR DESCRIPTION
We use this bundle on [baksla.sh](https://baksla.sh/) to programmatically minify HTML files ([SSG](https://github.com/bakslashHQ/baksla.sh/blob/77fe33902d3b5d73386b132bb23f62f4137e64ec/src/Shared/Infrastructure/StaticSiteGeneration/FilesystemStaticPageDumper.php#L38)), but today we ran into an issue where the site preview on LinkedIn wasn't working: our `og:image` tag was being ignored.

It turns out that LinkedIn's parser (https://www.linkedin.com/post-inspector/) doesn't work correctly when the `<head>` and `</head>` tags are missing... 😫 

This PR adds support for HTML and options (just one option for now, KISS), but only in the low-level `MinifyInterface::minify()` method.
I deliberately did not touch the bundle (i.e., adding configuration to `SensiolabsMinifyBundle` and modifying the `MinifierCompiler`, etc..), because I don't think it makes sense with the AssetMapper's integration (JS/CSS only).